### PR TITLE
Docsify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,14 @@
-# Pixie Labs Handbook
- 
-This is the Pixie Labs Handbook.
+# Welcome!
 
-It contains guides for how we work together as a team, grow as individuals,
-support our clients and build great software!
+Welcome to the Pixie Labs handbook! On this site you'll find _nearly_
+everything you need to know about working at Pixie Labs. The handbook is 
+perpetually a work-in-progress, evolving as we grow and change as a company.
 
-## Working at Pixie Labs
-
-- [Security](/01-working-at-pixie-labs/07-security.md)
-- [Tools for teamwork](/01-working-at-pixie-labs/08-tools.md)
-
-## Project management
-
-- [Estimating a project](/02-project-management/01-estimating.md)
-- [Working with designers](/02-project-management/02-working-with-designers.md)
-- [Beginning and ending projects](/02-project-management/03-beginning-and-ending.md)
-- [Project delivery metrics](/02-project-management/05-project-delivery-metrics.md)
-
-## Project delivery
-
-- [Priorities](/03-project-delivery/01-priorities.md)
-- [General Dos and Donts](/03-project-delivery/02-general-dos-donts.md)
-- [Style guidelines](/03-project-delivery/03-style-guidelines.md)
-- [Tools for development](/03-project-delivery/04-tools.md)
-- [Testing](/03-project-delivery/05-testing.md)
-- [Reviews](/03-project-delivery/06-reviews.md)
-- [Deploying](/03-project-delivery/07-deploying.md)
-
-## Ongoing support
-
-- [Types of support](/04-ongoing-support/01-types-of-support.md)
-- [Support processes](/04-ongoing-support/02-support-processes.md)
-- [Debugging](/04-ongoing-support/03-debugging.md)
-- [Alerts](/04-ongoing-support/04-alerts.md)
-
-## Personal development
-
-- [Time for us](/05-personal-development/02-time-for-us.md)
+If something seems to be missing, let’s have a chat!
 
 ## License
 
-This document is licensed under a
-[Creative Commons 1.0 Universal (CC0 1.0) License](https://creativecommons.org/publicdomain/zero/1.0/).
-That means it is in the public domain and you are free to use all or part of it
-with no attribution.
+This document is licensed under a [Creative Commons 1.0 Universal (CC0 1.0)
+License](https://creativecommons.org/publicdomain/zero/1.0/). That means it is
+in the public domain and you are free to use all or part of it with no
+attribution.

--- a/_coverpage.md
+++ b/_coverpage.md
@@ -1,0 +1,13 @@
+<img src="https://pixielabs.io/assets/logos/white-with-green-logo.svg"
+     style="max-width: 300px" />
+
+# Handbook
+
+> Guides for how we work together as a team, grow as individuals,
+support our clients and build great software!
+
+[GitHub](https://github.com/pixielabs/handbook/)
+[Start reading](#welcome)
+
+
+![color](#282f36)

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,32 @@
+- Working at Pixie Labs
+
+  - [Security](/01-working-at-pixie-labs/07-security.md)
+  - [Tools for teamwork](/01-working-at-pixie-labs/08-tools.md)
+
+- Project management
+
+  - [Estimating a project](/02-project-management/01-estimating.md)
+  - [Working with designers](/02-project-management/02-working-with-designers.md)
+  - [Beginning and ending projects](/02-project-management/03-beginning-and-ending.md)
+  - [Project delivery metrics](/02-project-management/05-project-delivery-metrics.md)
+
+- Project delivery
+
+  - [Priorities](/03-project-delivery/01-priorities.md)
+  - [General Dos and Donts](/03-project-delivery/02-general-dos-donts.md)
+  - [Style guidelines](/03-project-delivery/03-style-guidelines.md)
+  - [Tools for development](/03-project-delivery/04-tools.md)
+  - [Testing](/03-project-delivery/05-testing.md)
+  - [Reviews](/03-project-delivery/06-reviews.md)
+  - [Deploying](/03-project-delivery/07-deploying.md)
+
+- Ongoing support
+
+  - [Types of support](/04-ongoing-support/01-types-of-support.md)
+  - [Support processes](/04-ongoing-support/02-support-processes.md)
+  - [Debugging](/04-ongoing-support/03-debugging.md)
+  - [Alerts](/04-ongoing-support/04-alerts.md)
+
+- Personal development
+
+  - [Time for us](/05-personal-development/02-time-for-us.md)

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <!-- Font -->
   <link rel="preconnect" href="https://fonts.gstatic.com"> 
-<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
   <!-- Theme -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
   <!-- Custom theme styles
@@ -24,6 +24,8 @@
       --cover-blockquote-color: #fff;
 
       --base-font-size       : 18px;
+
+      --sidebar-width: 20rem;
     }
   </style>
 
@@ -31,6 +33,9 @@
 </head>
 <body>
   <div id="app"></div>
+  <!-- Plugins -->
+  <script src="//cdn.jsdelivr.net/npm/docsify-edit-on-github"></script>
+
   <script>
     window.$docsify = {
       coverpage: true,
@@ -39,10 +44,14 @@
       auto2top: true,
       subMaxLevel: 3,
       name: 'Handbook',
-      repo: 'https://github.com/pixielabs/handbook'
+      repo: 'https://github.com/pixielabs/handbook',
+      plugins: [
+        EditOnGithubPlugin.create('https://github.com/pixielabs/handbook/blob/master/', null, 'Edit')
+      ]
     }
   </script>
   <!-- Docsify v4 -->
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pixie Labs Handbook</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+  <!-- Font -->
+  <link rel="preconnect" href="https://fonts.gstatic.com"> 
+<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;1,100;1,300;1,400;1,700&display=swap" rel="stylesheet">
+  <!-- Theme -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
+  <!-- Custom theme styles
+       <https://jhildenbiddle.github.io/docsify-themeable/#/customization?id=theme> -->
+  <style>
+    :root {
+      --base-font-family: Lato, sans-serif;
+    }
+  </style>
+
+
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      coverpage: true,
+      loadSidebar: true,
+      subMaxLevel: 3,
+      name: 'Handbook',
+      repo: 'https://github.com/pixielabs/handbook'
+    }
+  </script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,14 @@
   <style>
     :root {
       --base-font-family: Lato, sans-serif;
+
+      --theme-hue       : 162;
+      --theme-saturation: 51%;
+      --theme-lightness : 46%;
+
+      --cover-blockquote-color: #fff;
+
+      --base-font-size       : 18px;
     }
   </style>
 
@@ -27,6 +35,8 @@
     window.$docsify = {
       coverpage: true,
       loadSidebar: true,
+      mergeNavbar: true,
+      auto2top: true,
       subMaxLevel: 3,
       name: 'Handbook',
       repo: 'https://github.com/pixielabs/handbook'


### PR DESCRIPTION
We've talked about turning our handbook into something a bit more readable; as just having it in a repo isn't _super_ great for clicking around.

Docsify took about 15 minutes to add this far. It needs some visual tweaking but it pretty much let me lay it over our existing Markdown with no changes.

Want to try it locally?

```sh
npm install -g docsify-cli
docsify serve
```

Some stuff still to do off the top of my head:

 - Work out how to deploy it & deploy to handbook.pixielabs.io
 - Look at how simple SSR would be
 - Fix some of the styling to better align with our styling
 - Pull some stuff out of CDNs?
 - Check if there are any docsify plugins (e.g. search) we want to add.